### PR TITLE
Population numbers. Such that Pop 5 doesn't mean 500'000 people in a …

### DIFF
--- a/PieAncientEuropeVI/CvGameCoreDLL/CvCity.cpp
+++ b/PieAncientEuropeVI/CvGameCoreDLL/CvCity.cpp
@@ -5515,7 +5515,12 @@ void CvCity::changePopulation(int iChange)
 
 long CvCity::getRealPopulation() const
 {
+    // Flunky for PAE: reduced population numbers for the statistic
+    // BtS original
+    /* 
 	return (((long)(pow((float)getPopulation(), 2.8f))) * 1000);
+    */
+	return (((long)(pow((float)getPopulation(), 2.8f))) * 100 + 400);
 }
 
 int CvCity::getHighestPopulation() const


### PR DESCRIPTION
…city. Pop 1 around 500 people, Pop 6 around 50.000. Pop 25 close to 1 M.

Previously: Pop^2.8 *1000.
Suggestion: round(Pop^2.8) * 100 + 400 yields Pop1: 500, Pop6: 15500, Pop25: 821200.